### PR TITLE
support swift pattern "UIImage(named: "xx")"

### DIFF
--- a/LSUnusedResources/Model/ResourceStringSearcher.m
+++ b/LSUnusedResources/Model/ResourceStringSearcher.m
@@ -176,7 +176,7 @@ typedef NS_ENUM(NSUInteger, LSFileType) {
             groupIndex = 1;
             break;
         case LSFileTypeSwift:
-            pattern = @"named:\"(\\S+)\"";//UIImage(named:"xx")
+            pattern = @"named:\\s*\"(\\S+)\"";//UIImage(named:"xx") or UIImage(named: "xx")
             groupIndex = 1;
             break;
         case LSFileTypeXib:


### PR DESCRIPTION
In my swift projects I usually have space between ":" and image name.